### PR TITLE
Issue: ArgumentCountError in StaticFileConfigDumper due to outdated service definition

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -16,6 +16,7 @@
         <service id="Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigDumper">
             <argument type="service" id="Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader"/>
             <argument type="service" id="Shopware\Storefront\Theme\ConfigLoader\DatabaseAvailableThemeProvider"/>
+            <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="shopware.filesystem.temp"/>
             <tag name="kernel.event_subscriber"/>
         </service>


### PR DESCRIPTION
### fix: update service definitions for Shopware 6.6.10 compatibility
Error Message:

> Uncaught Error: Too few arguments to function Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigDumper::__construct(), 3 passed [...] and exactly 4 expected

Adjusted service tags in services.xml to match changes introduced in Shopware commit 335ddca4a155bd977f8373bfa966eb27df2dd8e9. 

Ensures proper registration of 
**Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigDumper** service