### PR TITLE
Issue: ArgumentCountError in StaticFileConfigDumper due to outdated service definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "shopware/storefront": "^6.5"
+    "shopware/storefront": "^6.6.10"
   },
   "license": "MIT",
   "autoload": {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+x<?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -16,6 +16,7 @@
         <service id="Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigDumper">
             <argument type="service" id="Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader"/>
             <argument type="service" id="Shopware\Storefront\Theme\ConfigLoader\DatabaseAvailableThemeProvider"/>
+            <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="shopware.filesystem.temp"/>
             <tag name="kernel.event_subscriber"/>
         </service>


### PR DESCRIPTION
Sure! Here's a clear and well-written issue description you can use:

---

### **Issue: ArgumentCountError in StaticFileConfigDumper due to outdated service definition**

#### 🧨 Error:
```
Uncaught Error: Too few arguments to function Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigDumper::__construct(), 3 passed [...] and exactly 4 expected
```

#### 💡 Root Cause:
This error occurs because the service definition for `Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigDumper` in the plugin's `services.xml` is outdated. Shopware core introduced a fourth required argument to the constructor of `StaticFileConfigDumper` in [[commit 335ddca](https://github.com/shopware/shopware/commit/335ddca4a155bd977f8373bfa966eb27df2dd8e9)](https://github.com/shopware/shopware/commit/335ddca4a155bd977f8373bfa966eb27df2dd8e9). If the service is manually declared without updating the constructor arguments, the DI container will fail to instantiate the class.

#### ✅ Solution:
Update the plugin’s `services.xml` to include the missing fourth argument in the constructor definition, ensuring compatibility with Shopware 6.6.10 and later.
